### PR TITLE
Bug/fix carbons in docblocks

### DIFF
--- a/src/ModelAnalyzer.php
+++ b/src/ModelAnalyzer.php
@@ -239,7 +239,8 @@ class ModelAnalyzer {
 		$dates = $this->getDates($reflectionClass);
 		$propsToReturn = [];
 
-		$carbonString = config('modeldocumenter.importCarbon', false) ? 'Carbon' : 'Carbon\Carbon';
+		$carbonString = config('modeldocumenter.importCarbon', false) ? 'Carbon' : '\Carbon\Carbon';
+		$nullableCarbonString = $carbonString . '|null';
 
 		foreach ($properties as $property) {
 			$phpType = $this->dbHelper->dbTypeToPHP($property);
@@ -248,14 +249,13 @@ class ModelAnalyzer {
 			if ($phpType === 'int' && in_array($propName, $dates)) {
 				$phpType = $carbonString;
 			} elseif ($phpType === 'int|null' && in_array($propName, $dates)) {
-				$phpType = $carbonString . '|null';
+				$phpType = $nullableCarbonString;
 			}
 
 			$propsToReturn[$propName] = $phpType;
 
-
 			// If the model uses a Carbon we need to either import or fully qualify them with namespace
-			if ($phpType === 'Carbon' && !in_array('Carbon', $this->requiredImports)) {
+			if (($phpType === $carbonString || $phpType === $nullableCarbonString) && !in_array('Carbon', $this->requiredImports)) {
 				$this->requiredImports[] = 'Carbon';
 			}
 		}

--- a/src/ModelAnalyzer.php
+++ b/src/ModelAnalyzer.php
@@ -173,12 +173,7 @@ class ModelAnalyzer {
 	 */
 	protected function getDates(ReflectionClass $reflectionClass): array {
 		$instance = $reflectionClass->newInstance();
-		$dates = $reflectionClass->getProperty('dates');
-		$dates->setAccessible(true);
-		$datesValue = $dates->getValue($instance);
-		$dates->setAccessible(false);
-
-		return $datesValue;
+		return $instance->getDates();
 	}
 
 	/**
@@ -244,15 +239,16 @@ class ModelAnalyzer {
 		$dates = $this->getDates($reflectionClass);
 		$propsToReturn = [];
 
+		$carbonString = config('modeldocumenter.importCarbon', false) ? 'Carbon' : 'Carbon\Carbon';
+
 		foreach ($properties as $property) {
 			$phpType = $this->dbHelper->dbTypeToPHP($property);
 			$propName = $property->Field;
-
 			// If the prop is an integer and the property is in the $dates array, it is a Carbon
 			if ($phpType === 'int' && in_array($propName, $dates)) {
-				$phpType = 'Carbon';
+				$phpType = $carbonString;
 			} elseif ($phpType === 'int|null' && in_array($propName, $dates)) {
-				$phpType = 'Carbon|null';
+				$phpType = $carbonString . '|null';
 			}
 
 			$propsToReturn[$propName] = $phpType;

--- a/src/MySQLDBHelper.php
+++ b/src/MySQLDBHelper.php
@@ -8,6 +8,12 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class MySQLDBHelper implements DBHelper {
+	private string $carbonString;
+
+	public function __construct() {
+		$this->carbonString = config('modeldocumenter.importCarbon', false) ? 'Carbon' : '\Carbon\Carbon';
+	}
+
 	/**
 	 * { @inheritDoc }
 	 */
@@ -32,7 +38,7 @@ class MySQLDBHelper implements DBHelper {
 			|| Str::contains($mysqlType, 'enum')) {
 			$phpType = 'string';
 		} elseif (Str::contains($mysqlType, 'timestamp') || Str::contains($mysqlType, 'datetime')) {
-			$phpType = 'Carbon';
+			$phpType = $this->carbonString;
 		} elseif (Str::contains($mysqlType, 'decimal')) {
 			$phpType = 'float';
 		}

--- a/src/config/modeldocumenter.php
+++ b/src/config/modeldocumenter.php
@@ -1,9 +1,14 @@
 <?php
 
 return [
-	'modelPath' => 'App\Models',
+	'modelPath' => 'App',
+	// If recursive, it will scan php files in subfolders as well in its search for Models
 	'recursive' => true,
+	// Which lineendings does your project use? lf|cr|crlf|lfcr
 	'lineendings' => 'lf',
+	// Import Carbon\Carbon if there are any Carbons in the docblock properties?
+	'importCarbon' => false,
+	// Add any custom modules here
 	'modules' => [
 	],
 	'options' => [


### PR DESCRIPTION
* Added a setting to the config: `importCarbon` which defaults to `false`
    * If setting is `false`, carbons in docblocks will look like `Carbon\Carbon` instead of `Carbon`
* Carbon is actually imported now if needed and the setting is `true`